### PR TITLE
Hot reload using browser-sync as a webpack plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,1 +1,4 @@
-FROM gitpod/workspace-mysql
+FROM gitpod/workspace-mysq
+
+# Force the docker image to build by incrementing this value
+ENV INVALIDATE_CACHE=1

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-mysq
+FROM gitpod/workspace-mysql
 
 # Force the docker image to build by incrementing this value
 ENV INVALIDATE_CACHE=1

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
 FROM gitpod/workspace-mysql
 
 # Force the docker image to build by incrementing this value
-ENV INVALIDATE_CACHE=1
+ENV INVALIDATE_CACHE=2

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,8 @@ ports:
     
 tasks:
   - name: setup
-    init: npm install browser-sync --save-dev
+    init: |
+      npm install --save-dev browser-sync webpack-cli browser-sync-webpack-plugin
+  - openMode: split-right
     command: >
-      apachectl start &&
-      gp open public/index.php
+      apachectl start && ./node_modules/.bin/webpack --watch

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,8 @@ ports:
   - port: 3306
     onOpen: ignore
   - port: 8001
+    onOpen: ignore
+  - port: 3005
     onOpen: open-preview
     
 tasks:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,6 +8,7 @@ ports:
     
 tasks:
   - name: setup
+    init: npm install browser-sync --save-dev
     command: >
       apachectl start &&
       gp open public/index.php

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,7 @@ ports:
     
 tasks:
   - name: setup
-    before: npm install --save-dev browser-sync-webpack-plugin webpack-cli
+    before: npm install --save-dev browser-sync-webpack-plugin webpack-cli && gp sync-done npmdone
   - openMode: split-right
     command: >
-      apachectl start && ./node_modules/.bin/webpack --watch
+      gp sync-await npmdone && gp await-port 3306 apachectl start && ./node_modules/.bin/webpack --watch

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,8 +10,7 @@ ports:
     
 tasks:
   - name: setup
-    init: |
-      npm install --save-dev browser-sync-webpack-plugin webpack-cli
+    before: npm install --save-dev browser-sync-webpack-plugin webpack-cli
   - openMode: split-right
     command: >
       apachectl start && ./node_modules/.bin/webpack --watch

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,4 +13,4 @@ tasks:
     before: npm install --save-dev browser-sync-webpack-plugin webpack-cli && gp sync-done npmdone
   - openMode: split-right
     command: >
-      gp sync-await npmdone && gp await-port 3306 apachectl start && ./node_modules/.bin/webpack --watch
+      gp sync-await npmdone && gp await-port 3306 && apachectl start && ./node_modules/.bin/webpack --watch

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ ports:
 tasks:
   - name: setup
     init: |
-      npm install --save-dev browser-sync webpack-cli browser-sync-webpack-plugin
+      npm install --save-dev browser-sync-webpack-plugin webpack-cli
   - openMode: split-right
     command: >
       apachectl start && ./node_modules/.bin/webpack --watch

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,31 @@
+// Simple default webpack configuration to proxy apache with browser-sync for hot reloading
+// on Gitpod with dynamically served PHP files
+
+const { execSync } = require('child_process');
+const BrowserSyncPlugin = require('browser-sync-webpack-plugin')
+const PROXY_PORT=8001
+const BS_PORT = 3005
+const GP_URL = execSync(`gp url ${BS_PORT}`) 
+
+module.exports = {
+  mode: "development",
+  entry: {},
+  output: {},
+  plugins: [
+    new BrowserSyncPlugin(
+      {
+        ui: false,
+        proxy: {
+          target: `http://localhost:${PROXY_PORT}`
+        },
+        // Add other file types to be hot reloaded here in this array 
+        files: ["**/*.php"],
+        notify: true,
+        port: BS_PORT,
+        socket: {
+          domain: GP_URL
+        }
+      }
+    )
+  ]
+}


### PR DESCRIPTION
A basic hot reload setup that implements `browser-sync-webpack-plugin`  to watch dynamically served files such as PHP.

`webpack --watch` activates  BrowserSync on port 3005 via `webpack.config.js`  which watches PHP files and proxies the Apache server running on port 8001.

Gitpod waits for MySql on port 3006 and the npm install before is runs the `webpack --watch` which opens the preview browser

npm installs the following every time a Gitpod workspace is created or opened.
- `browser-sync-webpack-plugin`
- `webpack-cli`

 `.gitignore`: `node_modules` and `dist` directories